### PR TITLE
Use docker-compose to spawn dockerized tests

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  test:
+    image: node:alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: sh -c "yarn install && yarn test"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start": "NODE_OPTIONS='--max_old_space_size=490' probot run ./src/probot.js",
     "lint": "standard --fix",
     "test": "jest && standard",
+    "test:docker": "docker-compose up",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage",
     "dist": "ncc build src/action.js"
   },


### PR DESCRIPTION
This implementation no longer require DockerFile.
To run dockerized tests, you just need to run:
* npm run test:docker